### PR TITLE
Feat: Add toggle for LaTeX/text view

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -155,3 +155,16 @@ p {
 .equation-box .mathjax-wrapper, #focus-equation .mathjax-wrapper {
     font-size: 0.8em;
 }
+
+#toggle-view {
+    background-color: transparent;
+    color: #00FF41;
+    border: 1px solid #00FF41;
+    padding: 10px 20px;
+    cursor: pointer;
+    margin-bottom: 20px;
+}
+
+#toggle-view:hover {
+    background-color: rgba(0, 255, 65, 0.1);
+}

--- a/variables-equations-units.html
+++ b/variables-equations-units.html
@@ -1,279 +1,583 @@
-<h1>Extracted Equations, Variables, and Units (v1.7)</h1>
+<button id="toggle-view">Toggle LaTeX/Text</button>
 
-<p>Updated with corrections from review processes. Updates are based on the initial assessment (including dimensional consistency, standard aerospace notation, and OCR reconstructions), confirmed information from Bryson-Denham reference, from Rutowski context, and Heermann Reference. No new equations/variables added from first pass, only subsequent revisions. Page locations include. If you discover an error, please contact OODA WIKI.</p>
+<div id="text-view">
+    <h1>Extracted Equations, Variables, and Units (v1.7)</h1>
 
-<h2>Equations</h2>
-<p>Below is the updated comprehensive list of all unique equations extracted from the document, in order of appearance. Duplicates are removed, and OCR garbles (e.g., exponents, symbols) are reconstructed based on context, standard notation, and confirmations.</p>
+    <p>Updated with corrections from review processes. Updates are based on the initial assessment (including dimensional consistency, standard aerospace notation, and OCR reconstructions), confirmed information from Bryson-Denham reference, from Rutowski context, and Heermann Reference. No new equations/variables added from first pass, only subsequent revisions. Page locations include. If you discover an error, please contact OODA WIKI.</p>
 
-<p>r = V^2 / (g N_r)<br>
-   (Instantaneous maneuverability radius; Page02)</p>
+    <h2>Equations</h2>
+    <p>Below is the updated comprehensive list of all unique equations extracted from the document, in order of appearance. Duplicates are removed, and OCR garbles (e.g., exponents, symbols) are reconstructed based on context, standard notation, and confirmations.</p>
 
-<p>ω = g N_r / V<br>
-   (Instantaneous maneuverability rate; Page02)</p>
+    <p>r = V^2 / (g N_r)<br>
+       (Instantaneous maneuverability radius; Page02)</p>
 
-<p>E = W h + (1/2) m V^2<br>
-   (Total energy; derived from E = E_p + E_k, where E_p = W h and E_k = (1/2) m V^2; Page04, Appendix II Page40)</p>
+    <p>ω = g N_r / V<br>
+       (Instantaneous maneuverability rate; Page02)</p>
 
-<p>E = W (h + V^2 / (2g))<br>
-   (Total energy in terms of weight; Page04, Appendix II Page40)</p>
+    <p>E = W h + (1/2) m V^2<br>
+       (Total energy; derived from E = E_p + E_k, where E_p = W h and E_k = (1/2) m V^2; Page04, Appendix II Page40)</p>
 
-<p>E_s = h + V^2 / (2g)<br>
-   (Specific energy; Page04, Appendix II Page40)</p>
+    <p>E = W (h + V^2 / (2g))<br>
+       (Total energy in terms of weight; Page04, Appendix II Page40)</p>
 
-<p>dE_s / dt = P_s<br>
-   (Energy rate; Page04)</p>
+    <p>E_s = h + V^2 / (2g)<br>
+       (Specific energy; Page04, Appendix II Page40)</p>
 
-<p>P_s = (T - D) V / W<br>
-   (Specific excess power; Page04, Appendix II Page41)</p>
+    <p>dE_s / dt = P_s<br>
+       (Energy rate; Page04)</p>
 
-<p>(W/g) \dot{V} = T_a - D - W sin γ<br>
-   (Force balance along flight path; Appendix II Page41)</p>
+    <p>P_s = (T - D) V / W<br>
+       (Specific excess power; Page04, Appendix II Page41)</p>
 
-<p>T_a - D = W sin γ + (W/g) \dot{V}<br>
-   (Rearranged force balance; Appendix II Page41)</p>
+    <p>(W/g) \dot{V} = T_a - D - W sin γ<br>
+       (Force balance along flight path; Appendix II Page41)</p>
 
-<p>(T_a - D)/W = sin γ + (\dot{V}/g)<br>
-    (Normalized force balance; Appendix II Page41)</p>
+    <p>T_a - D = W sin γ + (W/g) \dot{V}<br>
+       (Rearranged force balance; Appendix II Page41)</p>
 
-<p>((T_a - D)/W) V = V sin γ + (V \dot{V})/g<br>
-    (Multiplied by V; Appendix II Page41)</p>
+    <p>(T_a - D)/W = sin γ + (\dot{V}/g)<br>
+        (Normalized force balance; Appendix II Page41)</p>
 
-<p>dh/dt + (V \dot{V})/g = ((T_a - D)/W) V<br>
-    (Since dh/dt = V sin γ; Appendix II Page41)</p>
+    <p>((T_a - D)/W) V = V sin γ + (V \dot{V})/g<br>
+        (Multiplied by V; Appendix II Page41)</p>
 
-<p>(∂P_s / ∂V)_{E_s = k} = 0<br>
-    (Rutkowski condition for minimum time path; Appendix II Page43)</p>
+    <p>dh/dt + (V \dot{V})/g = ((T_a - D)/W) V<br>
+        (Since dh/dt = V sin γ; Appendix II Page41)</p>
 
-<p>(∂P_s / ∂h)_{E_s = k} = 0<br>
-    (Alternative Rutkowski condition for minimum time path; Appendix II Page43)</p>
+    <p>(∂P_s / ∂V)_{E_s = k} = 0<br>
+        (Rutkowski condition for minimum time path; Appendix II Page43)</p>
 
-<p>ΔE_s = ∫ (dE_s / dt) dt<br>
-    (Integral for energy change; Appendix II Page43; truncated in text)</p>
+    <p>(∂P_s / ∂h)_{E_s = k} = 0<br>
+        (Alternative Rutkowski condition for minimum time path; Appendix II Page43)</p>
 
-<p>dE_s / dw_f = -P_s / ẇ_f<br>
-    (Energy per fuel weight; Appendix II Page43)</p>
+    <p>ΔE_s = ∫ (dE_s / dt) dt<br>
+        (Integral for energy change; Appendix II Page43; truncated in text)</p>
 
-<p>ΔE_s = -∫ (P_s / ẇ_f) dw_f<br>
-    (Integral for minimum fuel; Appendix II Page43)</p>
+    <p>dE_s / dw_f = -P_s / ẇ_f<br>
+        (Energy per fuel weight; Appendix II Page43)</p>
 
-<p>(∂(P_s / ẇ_f) / ∂V)_{E_s = k} = 0<br>
-    (Rutkowski condition for minimum fuel path; Appendix II Page43)</p>
+    <p>ΔE_s = -∫ (P_s / ẇ_f) dw_f<br>
+        (Integral for minimum fuel; Appendix II Page43)</p>
 
-<p>(∂(P_s / ẇ_f) / ∂h)_{E_s = k} = 0<br>
-    (Alternative Rutkowski condition for minimum fuel path; Appendix II Page43)</p>
+    <p>(∂(P_s / ẇ_f) / ∂V)_{E_s = k} = 0<br>
+        (Rutkowski condition for minimum fuel path; Appendix II Page43)</p>
 
-<p>E-M = (P_s^* / ẇ_f) W_f<br>
-    (Energy-maneuverability efficiency; Page11, Appendix II Page44)</p>
+    <p>(∂(P_s / ẇ_f) / ∂h)_{E_s = k} = 0<br>
+        (Alternative Rutkowski condition for minimum fuel path; Appendix II Page43)</p>
 
-<p>R = (V_ts / ẇ_f_avg) W_f + x<br>
-    (Range equation; Page13, Appendix II Page45)</p>
+    <p>E-M = (P_s^* / ẇ_f) W_f<br>
+        (Energy-maneuverability efficiency; Page11, Appendix II Page44)</p>
 
-<p>n_L = (q S C_{L_max}) / W<br>
-    (Maximum load factor; Appendix II Page40)</p>
+    <p>R = (V_ts / ẇ_f_avg) W_f + x<br>
+        (Range equation; Page13, Appendix II Page45)</p>
 
-<p>q = (1/2) ρ V^2<br>
-    (Dynamic pressure; Appendix II Page40)</p>
+    <p>n_L = (q S C_{L_max}) / W<br>
+        (Maximum load factor; Appendix II Page40)</p>
 
-<p>E-M = P_s^* W_f / ẇ_f<br>
-    (Alternative form of efficiency; Page11)</p>
+    <p>q = (1/2) ρ V^2<br>
+        (Dynamic pressure; Appendix II Page40)</p>
 
-<p>d(δx)/dt = F(t) δx + G(t) δu<br>
-    (Linear differential equation for perturbations; Appendix II Page52)</p>
+    <p>E-M = P_s^* W_f / ẇ_f<br>
+        (Alternative form of efficiency; Page11)</p>
 
-<p>dλ/dt = -F'(t) λ(t)<br>
-    (Adjoint differential equations; Appendix II Page54)</p>
+    <p>d(δx)/dt = F(t) δx + G(t) δu<br>
+        (Linear differential equation for perturbations; Appendix II Page52)</p>
 
-<p>(dρ)^2 = ∫ δu'(t) W(t) δu(t) dt<br>
-    (Integral constraint for perturbations; Appendix II Page55)</p>
+    <p>dλ/dt = -F'(t) λ(t)<br>
+        (Adjoint differential equations; Appendix II Page54)</p>
 
-<p>δu(t) = [W^{-1} G' λ_{ψΩ}] / (dρ) ± [W^{-1} G' λ_{ψΩ} - (I_{ψΩ} / I_{ΩΩ}) W^{-1} G' λ_{ψΩ}] * [√(I_{ψψ} δψ - I_{ψΩ} δΩ) / √(I_{ψψ} I_{ΩΩ} - (I_{ψΩ})^2)]<br>
-    (Perturbation in control variables; Appendix II Page55; complex matrix form)</p>
+    <p>(dρ)^2 = ∫ δu'(t) W(t) δu(t) dt<br>
+        (Integral constraint for perturbations; Appendix II Page55)</p>
 
-<p>n = (\dot{V} / g) + cos γ<br>
-    (Normal acceleration; Appendix II Page72)</p>
+    <p>δu(t) = [W^{-1} G' λ_{ψΩ}] / (dρ) ± [W^{-1} G' λ_{ψΩ} - (I_{ψΩ} / I_{ΩΩ}) W^{-1} G' λ_{ψΩ}] * [√(I_{ψψ} δψ - I_{ψΩ} δΩ) / √(I_{ψψ} I_{ΩΩ} - (I_{ψΩ})^2)]<br>
+        (Perturbation in control variables; Appendix II Page55; complex matrix form)</p>
 
-<p>sin γ̄ = (h_i - h_{i-1}) / (V̄ Δt)<br>
-    (Approximate pitch angle; Appendix II Page72)</p>
+    <p>n = (\dot{V} / g) + cos γ<br>
+        (Normal acceleration; Appendix II Page72)</p>
 
-<p>sin γ_i = 2 Δh / (V̄ Δt)<br>
-    (Estimate for sin γ_i; Appendix II Page72)</p>
+    <p>sin γ̄ = (h_i - h_{i-1}) / (V̄ Δt)<br>
+        (Approximate pitch angle; Appendix II Page72)</p>
 
-<p>γ̇ = (γ_i - γ_{i-1}) / Δt<br>
-    (Angular rate; Appendix II Page72)</p>
+    <p>sin γ_i = 2 Δh / (V̄ Δt)<br>
+        (Estimate for sin γ_i; Appendix II Page72)</p>
 
-<p>C̄_L = ΔC_L + √[ (T̄_a - W̄ (sin γ̄ + \dot{V}/g)) / (q̄ S) - (C_{D_0} + k (ΔC_L)^2) ] / √k<br>
-    (Coefficient of lift; Appendix II Page71)</p>
+    <p>γ̇ = (γ_i - γ_{i-1}) / Δt<br>
+        (Angular rate; Appendix II Page72)</p>
 
-<h2>Variables</h2>
-<p>Below is the updated list of all unique variables, alphabetized, with descriptions (inferred from context) and units (if stated). Additions/clarifications from review included (e.g., averaged variables). No changes.</p>
+    <p>C̄_L = ΔC_L + √[ (T̄_a - W̄ (sin γ̄ + \dot{V}/g)) / (q̄ S) - (C_{D_0} + k (ΔC_L)^2) ] / √k<br>
+        (Coefficient of lift; Appendix II Page71)</p>
 
-<ul>
-    <li>a: Acceleration along flight path (ft/sec²). <em>(Note: Superseded by \dot{V} in some contexts, but retained for generality.)</em></li>
-    <li>C_{D_0}: Zero-lift drag coefficient (dimensionless).</li>
-    <li>C_L: Coefficient of lift (dimensionless).</li>
-    <li>C_{L_max}: Maximum coefficient of lift (dimensionless).</li>
-    <li>ΔC_L: Value of C_L for minimum C_D (dimensionless).</li>
-    <li>D: Drag force (lb).</li>
-    <li>dE_s/dt: Energy rate (ft/sec; also P_s).</li>
-    <li>dh/dt: Altitude rate (ft/sec).</li>
-    <li>dt: Time increment (sec).</li>
-    <li>dV/dt: Velocity rate (ft/sec²). <em>(See also \dot{V}.)</em></li>
-    <li>dρ: Perturbation size (dimensionless in context).</li>
-    <li>dw_f: Differential fuel weight (lb).</li>
-    <li>dγ/dt (γ̇): Pitch angle rate (rad/sec).</li>
-    <li>δu(t): Perturbation in control variables (matrix; varies by component).</li>
-    <li>δx(t): Perturbation in state variables (matrix; varies by component).</li>
-    <li>δΩ: Change in stopping condition (varies).</li>
-    <li>δψ: Change in pay-off function (varies, e.g., time or weight).</li>
-    <li>E: Total energy (ft-lb).</li>
-    <li>E_k: Kinetic energy (ft-lb).</li>
-    <li>E_p: Potential energy (ft-lb).</li>
-    <li>E_s: Specific energy (ft).</li>
-    <li>E-M: Energy-maneuverability efficiency (ft; Page11). <em>(Update from better scan: Confirmed as "E-M".)</em></li>
-    <li>F(t): Jacobian matrix of state derivatives (matrix; dimensionless/various).</li>
-    <li>f_c: Fuel consumed (lb).</li>
-    <li>G(t): Jacobian matrix of control influences (matrix; dimensionless/various).</li>
-    <li>g: Gravitational acceleration (32.174 ft/sec²; often 32.2 ft/sec²).</li>
-    <li>h: Altitude (ft).</li>
-    <li>Δh: Altitude change (ft).</li>
-    <li>I_{ψψ}, I_{ψΩ}, I_{ΩΩ}: Influence integrals (matrix scalars; sec² or lb² depending on context). <em>(Update from Bryson-Denham: Confirmed subscripts.)</em></li>
-    <li>k: Induced drag parameter (dimensionless).</li>
-    <li>λ (various subscripts like λ_h, λ_v, etc.): Lagrange multipliers/influence functions (dimensionless or varies).</li>
-    <li>m: Aircraft mass (slugs).</li>
-    <li>M: Mach number (dimensionless).</li>
-    <li>n: Normal acceleration/load factor (g's; dimensionless).</li>
-    <li>n_L: Maximum load factor (dimensionless).</li>
-    <li>N_r: Radial g (dimensionless). <em>(Confirmed on PAGE13: Subscript "r" for radial.)</em></li>
-    <li>Ω: Stopping condition (varies, e.g., V - V_2 = 0).</li>
-    <li>P_s: Specific excess power (ft/sec).</li>
-    <li>P_s^*: Average specific excess power (ft/sec). <em>(Clarification: Peak or reference value.)</em></li>
-    <li>ψ: Pay-off function (e.g., -t for time or -W for fuel; sec or lb).</li>
-    <li>q: Dynamic pressure (lb/ft²).</li>
-    <li>q̄: Average dynamic pressure (lb/ft²).</li>
-    <li>r: Turn radius (ft).</li>
-    <li>R: Range (nautical miles or ft; Page13).</li>
-    <li>S: Wing reference area (ft²).</li>
-    <li>t: Time (sec).</li>
-    <li>T (or T_a): Thrust available (lb).</li>
-    <li>T̄_a: Average thrust available (lb).</li>
-    <li>V: True airspeed (ft/sec; sometimes knots or CAS in context).</li>
-    <li>\dot{V}: Acceleration along path (ft/sec²). <em>(Confirmed on Page41: V with dot for dV/dt.)</em></li>
-    <li>V̄: Average true airspeed (ft/sec).</li>
-    <li>V_ts: True airspeed for cruise (ft/sec).</li>
-    <li>W: Aircraft weight (lb).</li>
-    <li>W̄: Average aircraft weight (lb).</li>
-    <li>W_f: Fuel weight available (lb).</li>
-    <li>ẇ_f: Fuel flow rate (lb/sec).</li>
-    <li>ẇ_f_avg: Average fuel flow (lb/sec).</li>
-    <li>x: Horizontal distance traversed (nautical miles or ft).</li>
-    <li>Δx: Distance increment (ft or nautical miles).</li>
-    <li>γ: Pitch angle (rad or degrees).</li>
-    <li>γ̄: Average pitch angle (rad).</li>
-    <li>ρ: Air density (slugs/ft³).</li>
-    <li>ω: Turn rate (rad/sec or deg/sec). <em>(Confirmed on PAGE13: Greek omega "ω".)</em></li>
-</ul>
+    <h2>Variables</h2>
+    <p>Below is the updated list of all unique variables, alphabetized, with descriptions (inferred from context) and units (if stated). Additions/clarifications from review included (e.g., averaged variables). No changes.</p>
 
-<h2>Units of Measure</h2>
-<p>The document uses Imperial units primarily, with some dimensionless quantities. Below is the updated list of all unique units mentioned or implied. No changes.</p>
+    <ul>
+        <li>a: Acceleration along flight path (ft/sec²). <em>(Note: Superseded by \dot{V} in some contexts, but retained for generality.)</em></li>
+        <li>C_{D_0}: Zero-lift drag coefficient (dimensionless).</li>
+        <li>C_L: Coefficient of lift (dimensionless).</li>
+        <li>C_{L_max}: Maximum coefficient of lift (dimensionless).</li>
+        <li>ΔC_L: Value of C_L for minimum C_D (dimensionless).</li>
+        <li>D: Drag force (lb).</li>
+        <li>dE_s/dt: Energy rate (ft/sec; also P_s).</li>
+        <li>dh/dt: Altitude rate (ft/sec).</li>
+        <li>dt: Time increment (sec).</li>
+        <li>dV/dt: Velocity rate (ft/sec²). <em>(See also \dot{V}.)</em></li>
+        <li>dρ: Perturbation size (dimensionless in context).</li>
+        <li>dw_f: Differential fuel weight (lb).</li>
+        <li>dγ/dt (γ̇): Pitch angle rate (rad/sec).</li>
+        <li>δu(t): Perturbation in control variables (matrix; varies by component).</li>
+        <li>δx(t): Perturbation in state variables (matrix; varies by component).</li>
+        <li>δΩ: Change in stopping condition (varies).</li>
+        <li>δψ: Change in pay-off function (varies, e.g., time or weight).</li>
+        <li>E: Total energy (ft-lb).</li>
+        <li>E_k: Kinetic energy (ft-lb).</li>
+        <li>E_p: Potential energy (ft-lb).</li>
+        <li>E_s: Specific energy (ft).</li>
+        <li>E-M: Energy-maneuverability efficiency (ft; Page11). <em>(Update from better scan: Confirmed as "E-M".)</em></li>
+        <li>F(t): Jacobian matrix of state derivatives (matrix; dimensionless/various).</li>
+        <li>f_c: Fuel consumed (lb).</li>
+        <li>G(t): Jacobian matrix of control influences (matrix; dimensionless/various).</li>
+        <li>g: Gravitational acceleration (32.174 ft/sec²; often 32.2 ft/sec²).</li>
+        <li>h: Altitude (ft).</li>
+        <li>Δh: Altitude change (ft).</li>
+        <li>I_{ψψ}, I_{ψΩ}, I_{ΩΩ}: Influence integrals (matrix scalars; sec² or lb² depending on context). <em>(Update from Bryson-Denham: Confirmed subscripts.)</em></li>
+        <li>k: Induced drag parameter (dimensionless).</li>
+        <li>λ (various subscripts like λ_h, λ_v, etc.): Lagrange multipliers/influence functions (dimensionless or varies).</li>
+        <li>m: Aircraft mass (slugs).</li>
+        <li>M: Mach number (dimensionless).</li>
+        <li>n: Normal acceleration/load factor (g's; dimensionless).</li>
+        <li>n_L: Maximum load factor (dimensionless).</li>
+        <li>N_r: Radial g (dimensionless). <em>(Confirmed on PAGE13: Subscript "r" for radial.)</em></li>
+        <li>Ω: Stopping condition (varies, e.g., V - V_2 = 0).</li>
+        <li>P_s: Specific excess power (ft/sec).</li>
+        <li>P_s^*: Average specific excess power (ft/sec). <em>(Clarification: Peak or reference value.)</em></li>
+        <li>ψ: Pay-off function (e.g., -t for time or -W for fuel; sec or lb).</li>
+        <li>q: Dynamic pressure (lb/ft²).</li>
+        <li>q̄: Average dynamic pressure (lb/ft²).</li>
+        <li>r: Turn radius (ft).</li>
+        <li>R: Range (nautical miles or ft; Page13).</li>
+        <li>S: Wing reference area (ft²).</li>
+        <li>t: Time (sec).</li>
+        <li>T (or T_a): Thrust available (lb).</li>
+        <li>T̄_a: Average thrust available (lb).</li>
+        <li>V: True airspeed (ft/sec; sometimes knots or CAS in context).</li>
+        <li>\dot{V}: Acceleration along path (ft/sec²). <em>(Confirmed on Page41: V with dot for dV/dt.)</em></li>
+        <li>V̄: Average true airspeed (ft/sec).</li>
+        <li>V_ts: True airspeed for cruise (ft/sec).</li>
+        <li>W: Aircraft weight (lb).</li>
+        <li>W̄: Average aircraft weight (lb).</li>
+        <li>W_f: Fuel weight available (lb).</li>
+        <li>ẇ_f: Fuel flow rate (lb/sec).</li>
+        <li>ẇ_f_avg: Average fuel flow (lb/sec).</li>
+        <li>x: Horizontal distance traversed (nautical miles or ft).</li>
+        <li>Δx: Distance increment (ft or nautical miles).</li>
+        <li>γ: Pitch angle (rad or degrees).</li>
+        <li>γ̄: Average pitch angle (rad).</li>
+        <li>ρ: Air density (slugs/ft³).</li>
+        <li>ω: Turn rate (rad/sec or deg/sec). <em>(Confirmed on PAGE13: Greek omega "ω".)</em></li>
+    </ul>
 
-<table>
-    <thead>
-        <tr>
-            <th>Main Unit</th>
-            <th>Description</th>
-            <th>Sub Alternatives</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>deg</td>
-            <td>Degrees (for angles).</td>
-            <td>rad (radians), grad (gradians), arcmin (arcminutes), arcsec (arcseconds).</td>
-        </tr>
-        <tr>
-            <td>dimensionless</td>
-            <td>For ratios like Mach number, load factors (g's), coefficients (C_L, etc.).</td>
-            <td>None (inherently unitless; no direct alternatives).</td>
-        </tr>
-        <tr>
-            <td>ft</td>
-            <td>Feet (altitude, radius, energy units like ft-lb or specific energy in ft).</td>
-            <td>m (meters), km (kilometers), in (inches), yd (yards), mi (statute miles).</td>
-        </tr>
-        <tr>
-            <td>ft/sec</td>
-            <td>Feet per second (airspeed, excess power).</td>
-            <td>m/s (meters per second), km/h (kilometers per hour), mph (miles per hour), knots (nautical miles per hour).</td>
-        </tr>
-        <tr>
-            <td>ft/sec²</td>
-            <td>Feet per second squared (acceleration).</td>
-            <td>m/s² (meters per second squared), km/s² (kilometers per second squared), g (standard gravity units).</td>
-        </tr>
-        <tr>
-            <td>ft-lb</td>
-            <td>Foot-pounds (energy).</td>
-            <td>J (joules), N·m (newton-meters), kcal (kilocalories), kWh (kilowatt-hours).</td>
-        </tr>
-        <tr>
-            <td>ft/deg</td>
-            <td>Feet per degree (in missile envelopes; PAGE46).</td>
-            <td>m/deg (meters per degree), m/rad (meters per radian), km/deg (kilometers per degree).</td>
-        </tr>
-        <tr>
-            <td>g</td>
-            <td>Gravitational units (load factor; dimensionless but "g's").</td>
-            <td>m/s² (meters per second squared, where 1 g ≈ 9.80665 m/s²), ft/s² (feet per second squared, where 1 g ≈ 32.174 ft/s²).</td>
-        </tr>
-        <tr>
-            <td>knots</td>
-            <td>Knots (airspeed in some contexts, e.g., CAS; implied).</td>
-            <td>m/s (meters per second), km/h (kilometers per hour), mph (miles per hour), ft/s (feet per second).</td>
-        </tr>
-        <tr>
-            <td>lb</td>
-            <td>Pounds (weight, thrust, drag, fuel).</td>
-            <td>kg (kilograms), N (newtons, for force equivalents), g (grams), oz (ounces), ton (short tons).</td>
-        </tr>
-        <tr>
-            <td>lb/ft²</td>
-            <td>Pounds per square foot (dynamic pressure).</td>
-            <td>Pa (pascals), kg/m² (kilograms per square meter), psi (pounds per square inch), bar (bars).</td>
-        </tr>
-        <tr>
-            <td>lb/sec</td>
-            <td>Pounds per second (fuel flow).</td>
-            <td>kg/s (kilograms per second), g/s (grams per second), lb/min (pounds per minute).</td>
-        </tr>
-        <tr>
-            <td>nautical miles (implied as "miles")</td>
-            <td>For range (e.g., 64.4 nautical miles).</td>
-            <td>km (kilometers), m (meters), sm (statute miles), ft (feet).</td>
-        </tr>
-        <tr>
-            <td>rad</td>
-            <td>Radians (pitch angle).</td>
-            <td>deg (degrees), grad (gradians), arcmin (arcminutes), arcsec (arcseconds).</td>
-        </tr>
-        <tr>
-            <td>rad/sec</td>
-            <td>Radians per second (rates).</td>
-            <td>deg/s (degrees per second), rpm (revolutions per minute), Hz (hertz, for cycles per second).</td>
-        </tr>
-        <tr>
-            <td>sec</td>
-            <td>Seconds (time).</td>
-            <td>ms (milliseconds), min (minutes), h (hours), day (days).</td>
-        </tr>
-        <tr>
-            <td>slugs</td>
-            <td>Slugs (mass).</td>
-            <td>kg (kilograms), g (grams), lb (pounds, though lb is force; slug is mass in imperial).</td>
-        </tr>
-        <tr>
-            <td>slugs/ft³</td>
-            <td>Slugs per cubic foot (density).</td>
-            <td>kg/m³ (kilograms per cubic meter), g/cm³ (grams per cubic centimeter), lb/ft³ (pounds per cubic foot, though lb is force; slug/ft³ is mass density).</td>
-        </tr>
-    </tbody>
-</table>
+    <h2>Units of Measure</h2>
+    <p>The document uses Imperial units primarily, with some dimensionless quantities. Below is the updated list of all unique units mentioned or implied. No changes.</p>
+
+    <table>
+        <thead>
+            <tr>
+                <th>Main Unit</th>
+                <th>Description</th>
+                <th>Sub Alternatives</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>deg</td>
+                <td>Degrees (for angles).</td>
+                <td>rad (radians), grad (gradians), arcmin (arcminutes), arcsec (arcseconds).</td>
+            </tr>
+            <tr>
+                <td>dimensionless</td>
+                <td>For ratios like Mach number, load factors (g's), coefficients (C_L, etc.).</td>
+                <td>None (inherently unitless; no direct alternatives).</td>
+            </tr>
+            <tr>
+                <td>ft</td>
+                <td>Feet (altitude, radius, energy units like ft-lb or specific energy in ft).</td>
+                <td>m (meters), km (kilometers), in (inches), yd (yards), mi (statute miles).</td>
+            </tr>
+            <tr>
+                <td>ft/sec</td>
+                <td>Feet per second (airspeed, excess power).</td>
+                <td>m/s (meters per second), km/h (kilometers per hour), mph (miles per hour), knots (nautical miles per hour).</td>
+            </tr>
+            <tr>
+                <td>ft/sec²</td>
+                <td>Feet per second squared (acceleration).</td>
+                <td>m/s² (meters per second squared), km/s² (kilometers per second squared), g (standard gravity units).</td>
+            </tr>
+            <tr>
+                <td>ft-lb</td>
+                <td>Foot-pounds (energy).</td>
+                <td>J (joules), N·m (newton-meters), kcal (kilocalories), kWh (kilowatt-hours).</td>
+            </tr>
+            <tr>
+                <td>ft/deg</td>
+                <td>Feet per degree (in missile envelopes; PAGE46).</td>
+                <td>m/deg (meters per degree), m/rad (meters per radian), km/deg (kilometers per degree).</td>
+            </tr>
+            <tr>
+                <td>g</td>
+                <td>Gravitational units (load factor; dimensionless but "g's").</td>
+                <td>m/s² (meters per second squared, where 1 g ≈ 9.80665 m/s²), ft/s² (feet per second squared, where 1 g ≈ 32.174 ft/s²).</td>
+            </tr>
+            <tr>
+                <td>knots</td>
+                <td>Knots (airspeed in some contexts, e.g., CAS; implied).</td>
+                <td>m/s (meters per second), km/h (kilometers per hour), mph (miles per hour), ft/s (feet per second).</td>
+            </tr>
+            <tr>
+                <td>lb</td>
+                <td>Pounds (weight, thrust, drag, fuel).</td>
+                <td>kg (kilograms), N (newtons, for force equivalents), g (grams), oz (ounces), ton (short tons).</td>
+            </tr>
+            <tr>
+                <td>lb/ft²</td>
+                <td>Pounds per square foot (dynamic pressure).</td>
+                <td>Pa (pascals), kg/m² (kilograms per square meter), psi (pounds per square inch), bar (bars).</td>
+            </tr>
+            <tr>
+                <td>lb/sec</td>
+                <td>Pounds per second (fuel flow).</td>
+                <td>kg/s (kilograms per second), g/s (grams per second), lb/min (pounds per minute).</td>
+            </tr>
+            <tr>
+                <td>nautical miles (implied as "miles")</td>
+                <td>For range (e.g., 64.4 nautical miles).</td>
+                <td>km (kilometers), m (meters), sm (statute miles), ft (feet).</td>
+            </tr>
+            <tr>
+                <td>rad</td>
+                <td>Radians (pitch angle).</td>
+                <td>deg (degrees), grad (gradians), arcmin (arcminutes), arcsec (arcseconds).</td>
+            </tr>
+            <tr>
+                <td>rad/sec</td>
+                <td>Radians per second (rates).</td>
+                <td>deg/s (degrees per second), rpm (revolutions per minute), Hz (hertz, for cycles per second).</td>
+            </tr>
+            <tr>
+                <td>sec</td>
+                <td>Seconds (time).</td>
+                <td>ms (milliseconds), min (minutes), h (hours), day (days).</td>
+            </tr>
+            <tr>
+                <td>slugs</td>
+                <td>Slugs (mass).</td>
+                <td>kg (kilograms), g (grams), lb (pounds, though lb is force; slug is mass in imperial).</td>
+            </tr>
+            <tr>
+                <td>slugs/ft³</td>
+                <td>Slugs per cubic foot (density).</td>
+                <td>kg/m³ (kilograms per cubic meter), g/cm³ (grams per cubic centimeter), lb/ft³ (pounds per cubic foot, though lb is force; slug/ft³ is mass density).</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<div id="latex-view" style="display:none;">
+    <h1>Extracted Equations, Variables, and Units (v1.7)</h1>
+
+    <p>Updated with corrections from review processes. Updates are based on the initial assessment (including dimensional consistency, standard aerospace notation, and OCR reconstructions), confirmed information from Bryson-Denham reference, from Rutowski context, and Heermann Reference. No new equations/variables added from first pass, only subsequent revisions. Page locations include. If you discover an error, please contact OODA WIKI.</p>
+
+    <h2>Equations</h2>
+    <p>Below is the updated comprehensive list of all unique equations extracted from the document, in order of appearance. Duplicates are removed, and OCR garbles (e.g., exponents, symbols) are reconstructed based on context, standard notation, and confirmations.</p>
+
+    <p>$$r = \frac{V^2}{g N_r}$$<br>
+       (Instantaneous maneuverability radius; Page02)</p>
+
+    <p>$$\omega = \frac{g N_r}{V}$$<br>
+       (Instantaneous maneuverability rate; Page02)</p>
+
+    <p>$$E = W h + \frac{1}{2} m V^2$$<br>
+       (Total energy; derived from E = E_p + E_k, where E_p = W h and E_k = (1/2) m V^2; Page04, Appendix II Page40)</p>
+
+    <p>$$E = W (h + \frac{V^2}{2g})$$<br>
+       (Total energy in terms of weight; Page04, Appendix II Page40)</p>
+
+    <p>$$E_s = h + \frac{V^2}{2g}$$<br>
+       (Specific energy; Page04, Appendix II Page40)</p>
+
+    <p>$$\frac{dE_s}{dt} = P_s$$<br>
+       (Energy rate; Page04)</p>
+
+    <p>$$P_s = \frac{(T - D) V}{W}$$<br>
+       (Specific excess power; Page04, Appendix II Page41)</p>
+
+    <p>$$\frac{W}{g} \dot{V} = T_a - D - W \sin \gamma$$<br>
+       (Force balance along flight path; Appendix II Page41)</p>
+
+    <p>$$T_a - D = W \sin \gamma + \frac{W}{g} \dot{V}$$<br>
+       (Rearranged force balance; Appendix II Page41)</p>
+
+    <p>$$\frac{T_a - D}{W} = \sin \gamma + \frac{\dot{V}}{g}$$<br>
+        (Normalized force balance; Appendix II Page41)</p>
+
+    <p>$$(\frac{T_a - D}{W}) V = V \sin \gamma + \frac{V \dot{V}}{g}$$<br>
+        (Multiplied by V; Appendix II Page41)</p>
+
+    <p>$$\frac{dh}{dt} + \frac{V \dot{V}}{g} = (\frac{T_a - D}{W}) V$$<br>
+        (Since dh/dt = V sin γ; Appendix II Page41)</p>
+
+    <p>$$(\frac{\partial P_s}{\partial V})_{E_s = k} = 0$$<br>
+        (Rutkowski condition for minimum time path; Appendix II Page43)</p>
+
+    <p>$$(\frac{\partial P_s}{\partial h})_{E_s = k} = 0$$<br>
+        (Alternative Rutkowski condition for minimum time path; Appendix II Page43)</p>
+
+    <p>$$\Delta E_s = \int \frac{dE_s}{dt} dt$$<br>
+        (Integral for energy change; Appendix II Page43; truncated in text)</p>
+
+    <p>$$\frac{dE_s}{dw_f} = -\frac{P_s}{\dot{w}_f}$$<br>
+        (Energy per fuel weight; Appendix II Page43)</p>
+
+    <p>$$\Delta E_s = -\int \frac{P_s}{\dot{w}_f} dw_f$$<br>
+        (Integral for minimum fuel; Appendix II Page43)</p>
+
+    <p>$$(\frac{\partial(\frac{P_s}{\dot{w}_f})}{\partial V})_{E_s = k} = 0$$<br>
+        (Rutkowski condition for minimum fuel path; Appendix II Page43)</p>
+
+    <p>$$(\frac{\partial(\frac{P_s}{\dot{w}_f})}{\partial h})_{E_s = k} = 0$$<br>
+        (Alternative Rutkowski condition for minimum fuel path; Appendix II Page43)</p>
+
+    <p>$$E-M = \frac{P_s^*}{\dot{w}_f} W_f$$<br>
+        (Energy-maneuverability efficiency; Page11, Appendix II Page44)</p>
+
+    <p>$$R = \frac{V_{ts}}{\dot{w}_{f_{avg}}} W_f + x$$<br>
+        (Range equation; Page13, Appendix II Page45)</p>
+
+    <p>$$n_L = \frac{q S C_{L_{max}}}{W}$$<br>
+        (Maximum load factor; Appendix II Page40)</p>
+
+    <p>$$q = \frac{1}{2} \rho V^2$$<br>
+        (Dynamic pressure; Appendix II Page40)</p>
+
+    <p>$$E-M = \frac{P_s^* W_f}{\dot{w}_f}$$<br>
+        (Alternative form of efficiency; Page11)</p>
+
+    <p>$$\frac{d(\delta x)}{dt} = F(t) \delta x + G(t) \delta u$$<br>
+        (Linear differential equation for perturbations; Appendix II Page52)</p>
+
+    <p>$$\frac{d\lambda}{dt} = -F'(t) \lambda(t)$$<br>
+        (Adjoint differential equations; Appendix II Page54)</p>
+
+    <p>$$(d\rho)^2 = \int \delta u'(t) W(t) \delta u(t) dt$$<br>
+        (Integral constraint for perturbations; Appendix II Page55)</p>
+
+    <p>$$\delta u(t) = \frac{W^{-1} G' \lambda_{\psi\Omega}}{d\rho} \pm [W^{-1} G' \lambda_{\psi\Omega} - \frac{I_{\psi\Omega}}{I_{\Omega\Omega}} W^{-1} G' \lambda_{\psi\Omega}] \cdot \frac{\sqrt{I_{\psi\psi} \delta\psi - I_{\psi\Omega} \delta\Omega}}{\sqrt{I_{\psi\psi} I_{\Omega\Omega} - (I_{\psi\Omega})^2}}$$<br>
+        (Perturbation in control variables; Appendix II Page55; complex matrix form)</p>
+
+    <p>$$n = \frac{\dot{V}}{g} + \cos \gamma$$<br>
+        (Normal acceleration; Appendix II Page72)</p>
+
+    <p>$$\sin \bar{\gamma} = \frac{h_i - h_{i-1}}{\bar{V} \Delta t}$$<br>
+        (Approximate pitch angle; Appendix II Page72)</p>
+
+    <p>$$\sin \gamma_i = \frac{2 \Delta h}{\bar{V} \Delta t}$$<br>
+        (Estimate for sin γ_i; Appendix II Page72)</p>
+
+    <p>$$\dot{\gamma} = \frac{\gamma_i - \gamma_{i-1}}{\Delta t}$$<br>
+        (Angular rate; Appendix II Page72)</p>
+
+    <p>$$\bar{C}_L = \Delta C_L + \frac{\sqrt{\frac{\bar{T}_a - \bar{W} (\sin \bar{\gamma} + \frac{\dot{V}}{g})}{\bar{q} S} - (C_{D_0} + k (\Delta C_L)^2)}}{\sqrt{k}}$$<br>
+        (Coefficient of lift; Appendix II Page71)</p>
+
+    <h2>Variables</h2>
+    <p>Below is the updated list of all unique variables, alphabetized, with descriptions (inferred from context) and units (if stated). Additions/clarifications from review included (e.g., averaged variables). No changes.</p>
+
+    <ul>
+        <li>a: Acceleration along flight path (ft/sec²). <em>(Note: Superseded by \dot{V} in some contexts, but retained for generality.)</em></li>
+        <li>C_{D_0}: Zero-lift drag coefficient (dimensionless).</li>
+        <li>C_L: Coefficient of lift (dimensionless).</li>
+        <li>C_{L_max}: Maximum coefficient of lift (dimensionless).</li>
+        <li>ΔC_L: Value of C_L for minimum C_D (dimensionless).</li>
+        <li>D: Drag force (lb).</li>
+        <li>dE_s/dt: Energy rate (ft/sec; also P_s).</li>
+        <li>dh/dt: Altitude rate (ft/sec).</li>
+        <li>dt: Time increment (sec).</li>
+        <li>dV/dt: Velocity rate (ft/sec²). <em>(See also \dot{V}.)</em></li>
+        <li>dρ: Perturbation size (dimensionless in context).</li>
+        <li>dw_f: Differential fuel weight (lb).</li>
+        <li>dγ/dt (γ̇): Pitch angle rate (rad/sec).</li>
+        <li>δu(t): Perturbation in control variables (matrix; varies by component).</li>
+        <li>δx(t): Perturbation in state variables (matrix; varies by component).</li>
+        <li>δΩ: Change in stopping condition (varies).</li>
+        <li>δψ: Change in pay-off function (varies, e.g., time or weight).</li>
+        <li>E: Total energy (ft-lb).</li>
+        <li>E_k: Kinetic energy (ft-lb).</li>
+        <li>E_p: Potential energy (ft-lb).</li>
+        <li>E_s: Specific energy (ft).</li>
+        <li>E-M: Energy-maneuverability efficiency (ft; Page11). <em>(Update from better scan: Confirmed as "E-M".)</em></li>
+        <li>F(t): Jacobian matrix of state derivatives (matrix; dimensionless/various).</li>
+        <li>f_c: Fuel consumed (lb).</li>
+        <li>G(t): Jacobian matrix of control influences (matrix; dimensionless/various).</li>
+        <li>g: Gravitational acceleration (32.174 ft/sec²; often 32.2 ft/sec²).</li>
+        <li>h: Altitude (ft).</li>
+        <li>Δh: Altitude change (ft).</li>
+        <li>I_{ψψ}, I_{ψΩ}, I_{ΩΩ}: Influence integrals (matrix scalars; sec² or lb² depending on context). <em>(Update from Bryson-Denham: Confirmed subscripts.)</em></li>
+        <li>k: Induced drag parameter (dimensionless).</li>
+        <li>λ (various subscripts like λ_h, λ_v, etc.): Lagrange multipliers/influence functions (dimensionless or varies).</li>
+        <li>m: Aircraft mass (slugs).</li>
+        <li>M: Mach number (dimensionless).</li>
+        <li>n: Normal acceleration/load factor (g's; dimensionless).</li>
+        <li>n_L: Maximum load factor (dimensionless).</li>
+        <li>N_r: Radial g (dimensionless). <em>(Confirmed on PAGE13: Subscript "r" for radial.)</em></li>
+        <li>Ω: Stopping condition (varies, e.g., V - V_2 = 0).</li>
+        <li>P_s: Specific excess power (ft/sec).</li>
+        <li>P_s^*: Average specific excess power (ft/sec). <em>(Clarification: Peak or reference value.)</em></li>
+        <li>ψ: Pay-off function (e.g., -t for time or -W for fuel; sec or lb).</li>
+        <li>q: Dynamic pressure (lb/ft²).</li>
+        <li>q̄: Average dynamic pressure (lb/ft²).</li>
+        <li>r: Turn radius (ft).</li>
+        <li>R: Range (nautical miles or ft; Page13).</li>
+        <li>S: Wing reference area (ft²).</li>
+        <li>t: Time (sec).</li>
+        <li>T (or T_a): Thrust available (lb).</li>
+        <li>T̄_a: Average thrust available (lb).</li>
+        <li>V: True airspeed (ft/sec; sometimes knots or CAS in context).</li>
+        <li>\dot{V}: Acceleration along path (ft/sec²). <em>(Confirmed on Page41: V with dot for dV/dt.)</em></li>
+        <li>V̄: Average true airspeed (ft/sec).</li>
+        <li>V_ts: True airspeed for cruise (ft/sec).</li>
+        <li>W: Aircraft weight (lb).</li>
+        <li>W̄: Average aircraft weight (lb).</li>
+        <li>W_f: Fuel weight available (lb).</li>
+        <li>ẇ_f: Fuel flow rate (lb/sec).</li>
+        <li>ẇ_f_avg: Average fuel flow (lb/sec).</li>
+        <li>x: Horizontal distance traversed (nautical miles or ft).</li>
+        <li>Δx: Distance increment (ft or nautical miles).</li>
+        <li>γ: Pitch angle (rad or degrees).</li>
+        <li>γ̄: Average pitch angle (rad).</li>
+        <li>ρ: Air density (slugs/ft³).</li>
+        <li>ω: Turn rate (rad/sec or deg/sec). <em>(Confirmed on PAGE13: Greek omega "ω".)</em></li>
+    </ul>
+
+    <h2>Units of Measure</h2>
+    <p>The document uses Imperial units primarily, with some dimensionless quantities. Below is the updated list of all unique units mentioned or implied. No changes.</p>
+
+    <table>
+        <thead>
+            <tr>
+                <th>Main Unit</th>
+                <th>Description</th>
+                <th>Sub Alternatives</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>deg</td>
+                <td>Degrees (for angles).</td>
+                <td>rad (radians), grad (gradians), arcmin (arcminutes), arcsec (arcseconds).</td>
+            </tr>
+            <tr>
+                <td>dimensionless</td>
+                <td>For ratios like Mach number, load factors (g's), coefficients (C_L, etc.).</td>
+                <td>None (inherently unitless; no direct alternatives).</td>
+            </tr>
+            <tr>
+                <td>ft</td>
+                <td>Feet (altitude, radius, energy units like ft-lb or specific energy in ft).</td>
+                <td>m (meters), km (kilometers), in (inches), yd (yards), mi (statute miles).</td>
+            </tr>
+            <tr>
+                <td>ft/sec</td>
+                <td>Feet per second (airspeed, excess power).</td>
+                <td>m/s (meters per second), km/h (kilometers per hour), mph (miles per hour), knots (nautical miles per hour).</td>
+            </tr>
+            <tr>
+                <td>ft/sec²</td>
+                <td>Feet per second squared (acceleration).</td>
+                <td>m/s² (meters per second squared), km/s² (kilometers per second squared), g (standard gravity units).</td>
+            </tr>
+            <tr>
+                <td>ft-lb</td>
+                <td>Foot-pounds (energy).</td>
+                <td>J (joules), N·m (newton-meters), kcal (kilocalories), kWh (kilowatt-hours).</td>
+            </tr>
+            <tr>
+                <td>ft/deg</td>
+                <td>Feet per degree (in missile envelopes; PAGE46).</td>
+                <td>m/deg (meters per degree), m/rad (meters per radian), km/deg (kilometers per degree).</td>
+            </tr>
+            <tr>
+                <td>g</td>
+                <td>Gravitational units (load factor; dimensionless but "g's").</td>
+                <td>m/s² (meters per second squared, where 1 g ≈ 9.80665 m/s²), ft/s² (feet per second squared, where 1 g ≈ 32.174 ft/s²).</td>
+            </tr>
+            <tr>
+                <td>knots</td>
+                <td>Knots (airspeed in some contexts, e.g., CAS; implied).</td>
+                <td>m/s (meters per second), km/h (kilometers per hour), mph (miles per hour), ft/s (feet per second).</td>
+            </tr>
+            <tr>
+                <td>lb</td>
+                <td>Pounds (weight, thrust, drag, fuel).</td>
+                <td>kg (kilograms), N (newtons, for force equivalents), g (grams), oz (ounces), ton (short tons).</td>
+            </tr>
+            <tr>
+                <td>lb/ft²</td>
+                <td>Pounds per square foot (dynamic pressure).</td>
+                <td>Pa (pascals), kg/m² (kilograms per square meter), psi (pounds per square inch), bar (bars).</td>
+            </tr>
+            <tr>
+                <td>lb/sec</td>
+                <td>Pounds per second (fuel flow).</td>
+                <td>kg/s (kilograms per second), g/s (grams per second), lb/min (pounds per minute).</td>
+            </tr>
+            <tr>
+                <td>nautical miles (implied as "miles")</td>
+                <td>For range (e.g., 64.4 nautical miles).</td>
+                <td>km (kilometers), m (meters), sm (statute miles), ft (feet).</td>
+            </tr>
+            <tr>
+                <td>rad</td>
+                <td>Radians (pitch angle).</td>
+                <td>deg (degrees), grad (gradians), arcmin (arcminutes), arcsec (arcseconds).</td>
+            </tr>
+            <tr>
+                <td>rad/sec</td>
+                <td>Radians per second (rates).</td>
+                <td>deg/s (degrees per second), rpm (revolutions per minute), Hz (hertz, for cycles per second).</td>
+            </tr>
+            <tr>
+                <td>sec</td>
+                <td>Seconds (time).</td>
+                <td>ms (milliseconds), min (minutes), h (hours), day (days).</td>
+            </tr>
+            <tr>
+                <td>slugs</td>
+                <td>Slugs (mass).</td>
+                <td>kg (kilograms), g (grams), lb (pounds, though lb is force; slug is mass in imperial).</td>
+            </tr>
+            <tr>
+                <td>slugs/ft³</td>
+                <td>Slugs per cubic foot (density).</td>
+                <td>kg/m³ (kilograms per cubic meter), g/cm³ (grams per cubic centimeter), lb/ft³ (pounds per cubic foot, though lb is force; slug/ft³ is mass density).</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<script>
+    document.getElementById('toggle-view').addEventListener('click', function() {
+        var textView = document.getElementById('text-view');
+        var latexView = document.getElementById('latex-view');
+        if (textView.style.display === 'none') {
+            textView.style.display = 'block';
+            latexView.style.display = 'none';
+        } else {
+            textView.style.display = 'none';
+            latexView.style.display = 'block';
+        }
+        // Re-render MathJax
+        if (window.MathJax) {
+            window.MathJax.typeset();
+        }
+    });
+</script>


### PR DESCRIPTION
- I added a toggle button to the `variables-equations-units.html` file to switch between a text-based view and a LaTeX-rendered view of the equations.
- I styled the toggle button to be transparent with a HUD green color.
- The default view is the text-based view.