### PR TITLE
feat: Add equation selection and matrix population

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,10 @@
         .equation-box:hover {
             border-color: #00FF41;
         }
+        .selected-equation {
+            border-color: #00FF41;
+            background-color: #003300;
+        }
         #focus-equation {
             margin-top: 20px;
             padding: 20px;
@@ -57,6 +61,7 @@
         <section id="matrix">
             <h2>Matrix</h2>
             <button id="refresh-matrix">Refresh Matrix</button>
+            <button id="clear-matrix">Clear Matrix</button>
             <table id="matrix-table" border="1" style="width:100%; border-color:#00FF00;">
                 <thead>
                     <tr><th>Name</th><th>Amount</th><th>Unit</th><th>Actions</th></tr>
@@ -112,6 +117,27 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/10.6.4/math.min.js"></script>
     <!-- Link to particles.js -->
     <script src="particles.js"></script>
+    <script type="module">
+        import { EQUATIONS } from './equations.js';
+        import { handleEquationSelection } from './matrix.js';
+
+        const equationGrid = document.getElementById('equation-grid');
+        const focusEquationDiv = document.getElementById('focus-equation');
+
+        Object.keys(EQUATIONS).forEach(key => {
+            const eq = EQUATIONS[key];
+            const box = document.createElement('div');
+            box.className = 'equation-box';
+            box.textContent = key;
+            box.addEventListener('click', () => {
+                document.querySelectorAll('.equation-box').forEach(b => b.classList.remove('selected-equation'));
+                box.classList.add('selected-equation');
+                handleEquationSelection(key);
+                focusEquationDiv.textContent = `Selected: ${key} = f(${eq.inputs.join(', ')})`;
+            });
+            equationGrid.appendChild(box);
+        });
+    </script>
     <script>
         // Function to fetch and insert content
         function includeHTML() {

--- a/matrix.js
+++ b/matrix.js
@@ -1,6 +1,30 @@
 // matrix.js - Handles data entry inputs and populates matrix table
 import { EQUATIONS } from './equations.js';
 
+export function handleEquationSelection(equationKey) {
+    const equation = EQUATIONS[equationKey];
+    if (!equation) return;
+
+    const matrixTable = document.getElementById('matrix-table').querySelector('tbody');
+
+    equation.inputs.forEach(inputVar => {
+        if (!varExists(inputVar)) {
+            const row = document.createElement('tr');
+            row.innerHTML = `
+                <td>${inputVar}</td>
+                <td></td>
+                <td>${UNIT_AUTOCOMPLETE[inputVar] || ''}</td>
+                <td>
+                    <button class="edit-btn">Edit</button>
+                    <button class="delete-btn">Delete</button>
+                </td>
+            `;
+            matrixTable.appendChild(row);
+            addRowListeners(row);
+        }
+    });
+}
+
 // Preload EM variables from memo appendix (as array for now; later from JSON)
 // Uppercase for consistency
 const EM_VARIABLES = [
@@ -214,8 +238,22 @@ document.addEventListener('DOMContentLoaded', () => {
     const varUnitInput = document.getElementById('var-unit');
     const addButton = document.getElementById('add-var');
     const refreshButton = document.getElementById('refresh-matrix');
+    const clearButton = document.getElementById('clear-matrix');
     const matrixTable = document.getElementById('matrix-table').querySelector('tbody');
     const aircraftSearch = document.getElementById('aircraft-search');
+
+    if (clearButton) {
+        clearButton.addEventListener('click', () => {
+            matrixTable.innerHTML = `
+                <tr>
+                    <td>g</td>
+                    <td>32.174</td>
+                    <td>ft/sec²</td>
+                    <td></td>
+                </tr>
+            `;
+        });
+    }
 
     varNameInput.addEventListener('input', () => {
         const normalizedVar = normalizeVarName(varNameInput.value);


### PR DESCRIPTION
When an equation is selected from the equation grid, the necessary variables to solve that equation are added to the matrix with their amounts empty.

This commit introduces the following changes:
- Populates the equation grid with clickable equation boxes.
- When an equation is selected, its input variables are added to the matrix.
- The selected equation is highlighted in the grid.
- A 'Clear Matrix' button is added to reset the matrix.