### PR TITLE
Feat: Make toggle button sleeker and move it under H2

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -156,15 +156,16 @@ p {
     font-size: 0.8em;
 }
 
-#toggle-view {
+#toggle-view, #toggle-view-latex {
     background-color: transparent;
     color: #00FF41;
     border: 1px solid #00FF41;
-    padding: 10px 20px;
+    padding: 5px 10px;
     cursor: pointer;
-    margin-bottom: 20px;
+    margin-left: 20px;
+    font-size: 0.8em;
 }
 
-#toggle-view:hover {
+#toggle-view:hover, #toggle-view-latex:hover {
     background-color: rgba(0, 255, 65, 0.1);
 }

--- a/variables-equations-units.html
+++ b/variables-equations-units.html
@@ -1,11 +1,10 @@
-<button id="toggle-view">Toggle LaTeX/Text</button>
-
 <div id="text-view">
     <h1>Extracted Equations, Variables, and Units (v1.7)</h1>
 
     <p>Updated with corrections from review processes. Updates are based on the initial assessment (including dimensional consistency, standard aerospace notation, and OCR reconstructions), confirmed information from Bryson-Denham reference, from Rutowski context, and Heermann Reference. No new equations/variables added from first pass, only subsequent revisions. Page locations include. If you discover an error, please contact OODA WIKI.</p>
 
     <h2>Equations</h2>
+    <button id="toggle-view">Toggle LaTeX/Text</button>
     <p>Below is the updated comprehensive list of all unique equations extracted from the document, in order of appearance. Duplicates are removed, and OCR garbles (e.g., exponents, symbols) are reconstructed based on context, standard notation, and confirmations.</p>
 
     <p>r = V^2 / (g N_r)<br>
@@ -288,6 +287,7 @@
     <p>Updated with corrections from review processes. Updates are based on the initial assessment (including dimensional consistency, standard aerospace notation, and OCR reconstructions), confirmed information from Bryson-Denham reference, from Rutowski context, and Heermann Reference. No new equations/variables added from first pass, only subsequent revisions. Page locations include. If you discover an error, please contact OODA WIKI.</p>
 
     <h2>Equations</h2>
+    <button id="toggle-view-latex">Toggle LaTeX/Text</button>
     <p>Below is the updated comprehensive list of all unique equations extracted from the document, in order of appearance. Duplicates are removed, and OCR garbles (e.g., exponents, symbols) are reconstructed based on context, standard notation, and confirmations.</p>
 
     <p>$$r = \frac{V^2}{g N_r}$$<br>
@@ -565,7 +565,7 @@
 </div>
 
 <script>
-    document.getElementById('toggle-view').addEventListener('click', function() {
+    function toggleViews() {
         var textView = document.getElementById('text-view');
         var latexView = document.getElementById('latex-view');
         if (textView.style.display === 'none') {
@@ -579,5 +579,8 @@
         if (window.MathJax) {
             window.MathJax.typeset();
         }
-    });
+    }
+
+    document.getElementById('toggle-view').addEventListener('click', toggleViews);
+    document.getElementById('toggle-view-latex').addEventListener('click', toggleViews);
 </script>


### PR DESCRIPTION
- I've moved the toggle button to be under the `<h2>Equations</h2>` heading in both the text and LaTeX views.
- I've also updated the styles for the toggle button to be smaller and more integrated into the design.