### PR TITLE
feat: Make em-text display responsive and restyle navigation

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -125,6 +125,46 @@ p {
     }
 }
 
+/* EM Text Section */
+#em-text {
+    display: flex;
+    flex-direction: column;
+    height: 100%; /* Fill available height */
+    width: 100%; /* Fill available width */
+}
+
+#page-container {
+    flex-grow: 1; /* Allow container to grow */
+    overflow: auto; /* Add scrollbars if content overflows */
+    border: 1px solid #00FF00; /* Optional: for visibility */
+    width: 100%;
+}
+
+#page-iframe {
+    width: 100%;
+    height: 100%;
+    border: none; /* Remove default iframe border */
+}
+
+#pagination-controls {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 10px;
+}
+
+#pagination-controls button,
+#pagination-controls input {
+    background-color: transparent;
+    color: #00FF00; /* HUD green */
+    border: 1px solid #00FF00; /* HUD green */
+    margin: 0 5px;
+}
+
+#pagination-controls button {
+    cursor: pointer;
+}
+
 /* Data entry styling */
 #data-entry input[type="text"] {
     background-color: transparent;


### PR DESCRIPTION
This commit introduces the following changes:

- The display window now automatically adjusts to fill the width of a mobile or desktop browser page, respecting the chat panel.
- The arrow buttons and page number changer are now HUD green and transparent.
- The arrows and page number are centered.