### PR TITLE
fix: Connect em-text navigation buttons and remove input arrows

### DIFF
--- a/em-text.html
+++ b/em-text.html
@@ -5,9 +5,8 @@
     </div>
     <div id="pagination-controls">
         <button id="prev-page-button">&lt;</button>
-        <input type="number" id="page-number-input" value="1" min="1">
+        <input type="text" id="page-number-input" value="1" min="1">
         <button id="next-page-button">&gt;</button>
     </div>
 </section>
 <script src="em_text_pages.js"></script>
-<script src="em_text_navigation.js"></script>

--- a/index.html
+++ b/index.html
@@ -112,6 +112,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/10.6.4/math.min.js"></script>
     <!-- Link to particles.js -->
     <script src="particles.js"></script>
+    <!-- Link to em_text_navigation.js -->
+    <script src="em_text_navigation.js"></script>
     <script>
         // Function to fetch and insert content
         function includeHTML() {


### PR DESCRIPTION
This commit fixes the navigation buttons for the 'Energy-Maneuverability Text' section and removes the up/down arrows from the page number input.

- The `em_text_navigation.js` script is now loaded in `index.html` to ensure it runs after the buttons are rendered.
- The page number input type has been changed from 'number' to 'text' to remove the up/down arrows.